### PR TITLE
Fixed an issue with the like button and level when switching users

### DIFF
--- a/Assets/Scripts/SceneUIManager.cs
+++ b/Assets/Scripts/SceneUIManager.cs
@@ -1228,6 +1228,9 @@ public class SceneUIManager : MonoBehaviour
         foreach(LevelButtonListItem levelButtonListItem in levelButtonListItems) {
             if (childFavoriteLevelsIds.Contains(levelButtonListItem.levelId)) {
                 favoritesListManager.Add(levelButtonListItem);
+            } else if (levelButtonListItem.levelUIComponent != null) {
+                levelButtonListItem.levelUIComponent.LikeButton.interactable = true;
+			    levelButtonListItem.levelUIComponent.LikeLabel.text = "¿Te gusta el nivel? Agregálo a favoritos";
             }
         }
     }


### PR DESCRIPTION
Solucionado el siguiente error:

Cuando un usuario agregaba un nivel a favoritos, el botón de favoritos se desactivaba, y el label encima de botón cambiaba por "¡Agregado a favoritos!", sin embargo, si el usuario cerraba sesión e iniciaba una nueva sesión con otro usuario que no contenía este nivel en favoritos, el botón y el mensaje seguían apareciendo incorrectamente como si el nivel estuviera en su lista de favoritos, efectivamente impidiéndole agregarlo a su propia lista de favoritos.